### PR TITLE
use sys.path[0] instead of os.getcwd()

### DIFF
--- a/db_checker.py
+++ b/db_checker.py
@@ -7,9 +7,10 @@ import sqlite3
 from tkinter import messagebox
 from tkinter import * 
 import os
+import sys
 
 # Grabs the directory name
-path = os.getcwd()
+path = sys.path[0]
 
 # Used as a header when requesting a website
 header = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) '

--- a/pSearch.py
+++ b/pSearch.py
@@ -11,20 +11,21 @@ from PIL import  Image
 import math
 import random
 from zipfile import ZipFile
+import sys
 
 # Grabs the directory name
-path = os.getcwd()
+path = sys.path[0]
 
 # Extracts the module zip files needed for the program if they are not already there.
 if os.path.exists(path + "/bs4") == False and os.path.exists(path + "/customtkinter") == False:
-    for zipname in ["/bs4.zip", "/customtkinter.zip"]:
+    for zipname in [path + "/bs4.zip", path + "/customtkinter.zip"]:
         # opening the zip file in READ mode
-        with ZipFile(path + zipname, 'r') as zip: 
+        with ZipFile(zipname, 'r') as zip: 
             # printing all the contents of the zip file
             zip.printdir() 
             # extracting all the files
             print('Extracting all the files now...')
-            zip.extractall()
+            zip.extractall(path)
             print('Done!')
 else:
     print("Folders already exist, starting program...")


### PR DESCRIPTION
os.getcwd() gets the directory that the user is currently in, and sys.path[0] gets the directory of the script. sys.path[0] is better on Linux because you don't need to be in the same directory as the script to run it. this also benefits windows users if they are using the terminal.